### PR TITLE
ENH: Add support for passing in 3 part table identifiers to specify b…

### DIFF
--- a/docs/source/writing.rst
+++ b/docs/source/writing.rst
@@ -61,6 +61,22 @@ M (datetime)              TIMESTAMP
 If the data type inference does not suit your needs, supply a BigQuery schema
 as the ``table_schema`` parameter of :func:`~pandas_gbq.to_gbq`.
 
+Specifying a different billing project
+----------------------------
+
+If you want to upload to a table that is different from the project_id you
+need to run the job in, you can specify the project_id of the table as part
+of a three part identifier.
+
+
+.. code-block:: python
+
+   import pandas_gbq
+   pandas_gbq.to_gbq(
+       df, 'my_other_project.my_dataset.my_table', project_id=projectid, if_exists='fail',
+   )
+
+
 
 Troubleshooting Errors
 ----------------------

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -50,13 +50,16 @@ def encode_chunks(dataframe, chunksize=None):
 def load_chunks(
     client,
     dataframe,
+    project_id,
     dataset_id,
     table_id,
     chunksize=None,
     schema=None,
     location=None,
 ):
-    destination_table = client.dataset(dataset_id).table(table_id)
+    destination_table = client.dataset(dataset_id, project=project_id).table(
+        table_id
+    )
     job_config = bigquery.LoadJobConfig()
     job_config.write_disposition = "WRITE_APPEND"
     job_config.source_format = "CSV"

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -79,4 +79,6 @@ def gbq_dataset(project, credentials):
 def gbq_table(project, credentials, random_dataset_id):
     from pandas_gbq import gbq
 
-    return gbq._Table(project, project, random_dataset_id, credentials=credentials)
+    return gbq._Table(
+        project, project, random_dataset_id, credentials=credentials
+    )

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -72,11 +72,11 @@ def tokyo_table(bigquery_client, tokyo_dataset):
 def gbq_dataset(project, credentials):
     from pandas_gbq import gbq
 
-    return gbq._Dataset(project, credentials=credentials)
+    return gbq._Dataset(project, project, credentials=credentials)
 
 
 @pytest.fixture()
 def gbq_table(project, credentials, random_dataset_id):
     from pandas_gbq import gbq
 
-    return gbq._Table(project, random_dataset_id, credentials=credentials)
+    return gbq._Table(project, project, random_dataset_id, credentials=credentials)

--- a/tests/system/test_to_gbq.py
+++ b/tests/system/test_to_gbq.py
@@ -1,9 +1,9 @@
 import functools
 import pandas
 import pandas.testing
-
 import pytest
 
+from pandas_gbq import gbq
 
 pytest.importorskip("google.cloud.bigquery", minversion="1.24.0")
 
@@ -43,7 +43,39 @@ def test_float_round_trip(
     round_trip = bigquery_client.list_rows(table_id).to_dataframe()
     round_trip_floats = round_trip["float_col"].sort_values()
     pandas.testing.assert_series_equal(
-        round_trip_floats,
-        input_floats,
-        check_exact=True,
+        round_trip_floats, input_floats, check_exact=True
     )
+
+
+def test_include_project_name(
+    method_under_test, random_dataset_id, bigquery_client
+):
+    """Ensure that we can pass in a table identifier that includes a project.
+    """
+
+    table_id = "{}.{}.int_round_trip".format(
+        bigquery_client.project_id, random_dataset_id
+    )
+    input_series = pandas.Series([1, 2], name="int_col")
+    df = pandas.DataFrame({"int_col": input_series})
+    method_under_test(df, table_id)
+
+    round_trip = bigquery_client.list_rows(table_id).to_dataframe()
+    round_trip_data = round_trip["int_col"].sort_values()
+    pandas.testing.assert_series_equal(
+        round_trip_data, input_series, check_exact=True
+    )
+
+
+def test_include_project_name_failure(
+    method_under_test, random_dataset_id, bigquery_client
+):
+    """Ensure that we can pass in a table identifier that includes a project.
+    """
+    with pytest.raises(gbq.GenericGBQException):
+        table_id = "{}.{}.int_round_trip".format(
+            "this_project_does_not_exist", random_dataset_id
+        )
+        input_series = pandas.Series([1, 2], name="int_col")
+        df = pandas.DataFrame({"int_col": input_series})
+        method_under_test(df, table_id)

--- a/tests/system/test_to_gbq.py
+++ b/tests/system/test_to_gbq.py
@@ -50,8 +50,7 @@ def test_float_round_trip(
 def test_include_project_name(
     method_under_test, random_dataset_id, bigquery_client
 ):
-    """Ensure that we can pass in a table identifier that includes a project.
-    """
+    """Ensure that we can pass in a table identifier that includes a project."""
 
     table_id = "{}.{}.int_round_trip".format(
         bigquery_client.project_id, random_dataset_id
@@ -70,8 +69,7 @@ def test_include_project_name(
 def test_include_project_name_failure(
     method_under_test, random_dataset_id, bigquery_client
 ):
-    """Ensure that we can pass in a table identifier that includes a project.
-    """
+    """Ensure that we can pass in a table identifier that includes a project."""
     with pytest.raises(gbq.GenericGBQException):
         table_id = "{}.{}.int_round_trip".format(
             "this_project_does_not_exist", random_dataset_id

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -248,8 +248,8 @@ def test_to_gbq_doesnt_run_query(
 def test_to_gbq_w_empty_df(mock_bigquery_client):
     import google.api_core.exceptions
 
-    mock_bigquery_client.get_table.side_effect = google.api_core.exceptions.NotFound(
-        "my_table"
+    mock_bigquery_client.get_table.side_effect = (
+        google.api_core.exceptions.NotFound("my_table")
     )
     gbq.to_gbq(DataFrame(), "my_dataset.my_table", project_id="1234")
     mock_bigquery_client.create_table.assert_called_with(mock.ANY)
@@ -260,11 +260,11 @@ def test_to_gbq_w_empty_df(mock_bigquery_client):
 def test_to_gbq_creates_dataset(mock_bigquery_client):
     import google.api_core.exceptions
 
-    mock_bigquery_client.get_table.side_effect = google.api_core.exceptions.NotFound(
-        "my_table"
+    mock_bigquery_client.get_table.side_effect = (
+        google.api_core.exceptions.NotFound("my_table")
     )
-    mock_bigquery_client.get_dataset.side_effect = google.api_core.exceptions.NotFound(
-        "my_dataset"
+    mock_bigquery_client.get_dataset.side_effect = (
+        google.api_core.exceptions.NotFound("my_dataset")
     )
     gbq.to_gbq(DataFrame([[1]]), "my_dataset.my_table", project_id="1234")
     mock_bigquery_client.create_dataset.assert_called_with(mock.ANY)


### PR DESCRIPTION
This enables the following examples of specifying a table project independently of the billing project.

```
pandas_gbq.to_gbq(df, '`dataset.table`', project='other_project')

pandas_gbq.to_gbq(df, 'project.dataset.table', project='other_project')

pandas_gbq.to_gbq(df, '`project`.dataset.table', project='other_project')

pandas_gbq.to_gbq(df, '`project.dataset.table`', project='other_project')
```

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `nox -s blacken lint`
- [ ] `docs/source/changelog.rst` entry